### PR TITLE
chore: setup redux store

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,25 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { Provider } from "react-redux";
+import { persistStore } from "redux-persist";
+import { PersistGate } from "redux-persist/integration/react";
+import App from "./App";
+import "./index.css";
+import { store } from "./redux/store/store";
+import reportWebVitals from "./reportWebVitals";
+
+let persistor = persistStore(store);
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        <App />
+      </PersistGate>
+    </Provider>
   </React.StrictMode>
 );
 

--- a/src/redux/features/chatSlice.ts
+++ b/src/redux/features/chatSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { MessageProps } from "../../types/message";
+import { RootState } from "../store/store";
+
+interface ChatState {
+  messages: MessageProps[];
+}
+
+const initialState: ChatState = {
+  messages: [],
+};
+
+export const chatSlice = createSlice({
+  name: "chatRoom",
+  initialState,
+  reducers: {
+    saveMessage: (state, action) => {
+      state.messages.push(action.payload);
+    },
+  },
+});
+
+export const { saveMessage } = chatSlice.actions;
+
+export const selectMessages = (state: RootState) => state.chatData.messages;
+
+export default chatSlice.reducer;

--- a/src/redux/store/hooks.ts
+++ b/src/redux/store/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "./store";
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/redux/store/store.ts
+++ b/src/redux/store/store.ts
@@ -1,0 +1,56 @@
+import {
+  combineReducers,
+  configureStore,
+  PreloadedState,
+} from "@reduxjs/toolkit";
+import chatReducer from "../features/chatSlice";
+
+import {
+  FLUSH,
+  PAUSE,
+  PERSIST,
+  persistReducer,
+  PURGE,
+  REGISTER,
+  REHYDRATE,
+} from "redux-persist";
+import storage from "redux-persist/lib/storage";
+import { createStateSyncMiddleware } from "redux-state-sync";
+
+const persistConfig = {
+  key: "root",
+  version: 1,
+  storage,
+};
+
+const rootReducer = combineReducers({
+  chatData: chatReducer,
+});
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+const config = {
+  blacklist: ["persist/PERSIST", "persist/REHYDRATE"],
+};
+const syncStateMiddleware = [createStateSyncMiddleware(config)];
+
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }).prepend(syncStateMiddleware),
+});
+
+export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
+  return configureStore({
+    reducer: rootReducer,
+    preloadedState,
+  });
+};
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export type AppStore = ReturnType<typeof setupStore>;

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,0 +1,5 @@
+export type MessageProps = {
+  message: string;
+  sender: string;
+  time: string;
+};


### PR DESCRIPTION
Setup the redux store with Redux toolkit, Redux-persist and redux-state-async

Redux store enables you to set up a store. however, the state of the store is lost when the user refreshes. To solve this problem we use Redux-persist which enables the store to be saved into local storage and persists after reloads. 

Lastly, Redux state async helps synchronise the redux state across multiple tabs. 